### PR TITLE
support displaying bd cad objects with color tagged

### DIFF
--- a/example/object.py
+++ b/example/object.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from build123d import *  # Also works with cadquery objects!
+from build123d import Compound
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -15,9 +16,14 @@ with BuildPart() as example:
     Box(10, 10, 5)
     Cylinder(4, 5, mode=Mode.SUBTRACT)
 
-# Show it in the frontend with hot-reloading
-show(example)
+# Custom colors (optional)
+example.color = (0.1, 0.3, 0.1, 1)  # RGBA
+to_highlight = example.edges().group_by(Axis.Z)[-1]
+example_hl = Compound(to_highlight).translate((0, 0, 1e-3))  # To avoid z-fighting
+example_hl.color = (1, 1, .0, 1)
 
+# Show it in the frontend with hot-reloading
+show(example, example_hl)
 
 # %%
 

--- a/yacv_server/cad.py
+++ b/yacv_server/cad.py
@@ -10,12 +10,23 @@ from OCP.TopExp import TopExp
 from OCP.TopLoc import TopLoc_Location
 from OCP.TopTools import TopTools_IndexedMapOfShape
 from OCP.TopoDS import TopoDS_Shape
-from build123d import Compound, Shape
+from build123d import Compound, Shape, Color
 
 from yacv_server.gltf import GLTFMgr
 
 CADCoreLike = Union[TopoDS_Shape, TopLoc_Location]  # Faces, Edges, Vertices and Locations for now
 CADLike = Union[CADCoreLike, any]  # build123d and cadquery types
+ColorTuple = Tuple[float, float, float, float]
+
+def get_color(obj: CADLike) -> Optional[ColorTuple]:
+    """Get color from a CAD Object"""
+
+    if 'color' in dir(obj):
+        if isinstance(obj.color, tuple):
+            return obj.color
+        if isinstance(obj.color, Color):
+            return obj.color.to_tuple()
+    return None
 
 
 def get_shape(obj: CADLike, error: bool = True) -> Optional[CADCoreLike]:

--- a/yacv_server/logo.py
+++ b/yacv_server/logo.py
@@ -16,18 +16,25 @@ def build_logo(text: bool = True) -> Dict[str, Union[Part, Location, str]]:
             text_at_plane = Plane.YZ
             text_at_plane.origin = faces().group_by(Axis.X)[-1].face().center()
             with BuildSketch(text_at_plane.location):
-                Text('Yet Another\nCAD Viewer', 7, font_path='/usr/share/fonts/TTF/OpenSans-Regular.ttf')
+                Text('Yet Another\nCAD Viewer', 6, font_path='/usr/share/fonts/TTF/Hack-Regular.ttf')
             extrude(amount=1)
+    logo_obj.color = (0.7, 0.4, 0.1, 1) # Custom color for faces
 
+    # Highlight text edges with a custom color
+    to_highlight = logo_obj.edges().group_by(Axis.X)[-1]
+    logo_obj_hl = Compound(to_highlight).translate((1e-3, 0, 0))  # To avoid z-fighting
+    logo_obj_hl.color = (0, 0.3, 0.3, 1)
+
+    # Add a logo image to the CAD part
     logo_img_location = logo_obj.faces().group_by(Axis.X)[0].face().center_location
     logo_img_location *= Location((0, 0, 4e-2), (0, 0, 90))  # Avoid overlapping and adjust placement
-
     logo_img_path = os.path.join(ASSETS_DIR, 'img.jpg')
     img_glb_bytes, img_name = image_to_gltf(logo_img_path, logo_img_location, height=18)
 
+    # Add an animated fox to the CAD part
     fox_glb_bytes = open(os.path.join(ASSETS_DIR, 'fox.glb'), 'rb').read()
 
-    return {'fox': fox_glb_bytes, 'logo': logo_obj, 'location': logo_img_location, img_name: img_glb_bytes}
+    return {'fox': fox_glb_bytes, 'logo': logo_obj, 'logo_hl': logo_obj_hl, 'location': logo_img_location, img_name: img_glb_bytes}
 
 
 if __name__ == "__main__":

--- a/yacv_server/tessellate.py
+++ b/yacv_server/tessellate.py
@@ -36,7 +36,7 @@ def tessellate(
         vertex_to_faces: Dict[str, List[TopoDS_Face]] = {}
         if faces:
             for face in shape.faces():
-                _tessellate_face(mgr, face.wrapped, tolerance, angular_tolerance, color)
+                _tessellate_face(mgr, face.wrapped, tolerance, angular_tolerance, obj_color)
                 if edges:
                     for edge in face.edges():
                         edge_to_faces[edge.wrapped] = edge_to_faces.get(edge.wrapped, []) + [face.wrapped]


### PR DESCRIPTION
This PR adds support for YACV to display different colors in objects as set forth in build123d objects in "color" attributes.

This is particularly helpful when working with larger assemblies where there are a number of components and different colors are used to distinguish them