### PR TITLE
Enable selection of base texture of models via environment variables

### DIFF
--- a/assets/licenses.txt
+++ b/assets/licenses.txt
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @google/model-viewer@3.5.0
+ - @google/model-viewer@4.0.0
 
 This package contains the following license and notice below:
 
@@ -980,7 +980,7 @@ third-party archives.
 
 The following npm package may be included in this product:
 
- - typescript@5.6.2
+ - typescript@5.6.3
 
 This package contains the following license and notice below:
 
@@ -1458,7 +1458,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - three-mesh-bvh@0.8.0
+ - three-mesh-bvh@0.8.2
 
 This package contains the following license and notice below:
 
@@ -1692,7 +1692,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - three@0.163.0
+ - three@0.169.0
 
 This package contains the following license and notice below:
 
@@ -1782,7 +1782,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - vuetify@3.7.2
+ - vuetify@3.7.3
 
 This package contains the following license and notice below:
 
@@ -1812,16 +1812,16 @@ THE SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - @vue/compiler-core@3.5.7
- - @vue/compiler-dom@3.5.7
- - @vue/compiler-sfc@3.5.7
- - @vue/compiler-ssr@3.5.7
- - @vue/reactivity@3.5.7
- - @vue/runtime-core@3.5.7
- - @vue/runtime-dom@3.5.7
- - @vue/server-renderer@3.5.7
- - @vue/shared@3.5.7
- - vue@3.5.7
+ - @vue/compiler-core@3.5.12
+ - @vue/compiler-dom@3.5.12
+ - @vue/compiler-sfc@3.5.12
+ - @vue/compiler-ssr@3.5.12
+ - @vue/reactivity@3.5.12
+ - @vue/runtime-core@3.5.12
+ - @vue/runtime-dom@3.5.12
+ - @vue/server-renderer@3.5.12
+ - @vue/shared@3.5.12
+ - vue@3.5.12
 
 These packages each contain the following license and notice below:
 
@@ -1851,7 +1851,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - ktx-parse@0.7.0
+ - ktx-parse@0.7.1
 
 This package contains the following license and notice below:
 
@@ -1913,9 +1913,9 @@ SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - @gltf-transform/core@4.0.8
- - @gltf-transform/extensions@4.0.8
- - @gltf-transform/functions@4.0.8
+ - @gltf-transform/core@4.0.10
+ - @gltf-transform/extensions@4.0.10
+ - @gltf-transform/functions@4.0.10
 
 These packages each contain the following license and notice below:
 

--- a/example/object.py
+++ b/example/object.py
@@ -22,8 +22,11 @@ to_highlight = example.edges().group_by(Axis.Z)[-1]
 example_hl = Compound(to_highlight).translate((0, 0, 1e-3))  # To avoid z-fighting
 example_hl.color = (1, 1, .0, 1)
 
-# Show it in the frontend with hot-reloading
-show(example, example_hl)
+# Show it in the frontend with hot-reloading (texture and other keyword arguments are optional)
+texture = (  # MIT License Framework7 Line Icons: https://www.svgrepo.com/svg/437552/checkmark-seal
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASAQAAAAB+tbP6AAAAQ0lEQVQI12P4b3+A4Z/8AYYHBw8w"
+    "HHxwgOH8HyD+AsRPDjDMP+fAYD+fgcESiGfYOTCcqTnAcK4GogakFqQHpBdoBgAbGiPSbdzkhgAAAABJRU5ErkJggg==")
+show(example, example_hl, texture=texture)
 
 # %%
 

--- a/yacv_server/cad.py
+++ b/yacv_server/cad.py
@@ -19,19 +19,20 @@ CADLike = Union[CADCoreLike, any]  # build123d and cadquery types
 ColorTuple = Tuple[float, float, float, float]
 
 
-def get_color(obj: CADLike) -> Optional[ColorTuple]:
-    """Get color from a CAD Object"""
+def get_color(obj: any) -> Optional[ColorTuple]:
+    """Get color from a CAD Object or any other color-like object"""
     if 'color' in dir(obj):
-        if isinstance(obj.color, tuple):
-            c = None
-            if len(obj.color) == 3:
-                c = obj.color + (1,)
-            elif len(obj.color) == 4:
-                c = obj.color
-            # noinspection PyTypeChecker
-            return [min(max(float(x), 0), 1) for x in c]
-        if isinstance(obj.color, Color):
-            return obj.color.to_tuple()
+        obj = obj.color
+    if isinstance(obj, tuple):
+        c = None
+        if len(obj) == 3:
+            c = obj + (1,)
+        elif len(obj) == 4:
+            c = obj
+        # noinspection PyTypeChecker
+        return [min(max(float(x), 0), 1) for x in c]
+    if isinstance(obj, Color):
+        return obj.to_tuple()
     return None
 
 
@@ -181,7 +182,7 @@ def image_to_gltf(source: str | bytes, center: any, width: Optional[float] = Non
     return b''.join(mgr.build().save_to_bytes()), name
 
 
-def _hashcode(obj: Union[bytes, CADCoreLike], color: Optional[ColorTuple], **extras) -> str:
+def _hashcode(obj: Union[bytes, CADCoreLike], **extras) -> str:
     """Utility to compute the STABLE hash code of a shape"""
     # NOTE: obj.HashCode(MAX_HASH_CODE) is not stable across different runs of the same program
     # This is best-effort and not guaranteed to be unique
@@ -189,8 +190,6 @@ def _hashcode(obj: Union[bytes, CADCoreLike], color: Optional[ColorTuple], **ext
     for k, v in extras.items():
         hasher.update(str(k).encode())
         hasher.update(str(v).encode())
-    if color:
-        hasher.update(str(color).encode())
     if isinstance(obj, bytes):
         hasher.update(obj)
     elif isinstance(obj, TopLoc_Location):

--- a/yacv_server/logo.py
+++ b/yacv_server/logo.py
@@ -18,7 +18,6 @@ def build_logo(text: bool = True) -> Dict[str, Union[Part, Location, str]]:
             with BuildSketch(text_at_plane.location):
                 Text('Yet Another\nCAD Viewer', 6, font_path='/usr/share/fonts/TTF/Hack-Regular.ttf')
             extrude(amount=1)
-    logo_obj.color = (0.7, 0.4, 0.1, 1) # Custom color for faces
 
     # Highlight text edges with a custom color
     to_highlight = logo_obj.edges().group_by(Axis.X)[-1]

--- a/yacv_server/tessellate.py
+++ b/yacv_server/tessellate.py
@@ -24,7 +24,6 @@ def tessellate(
         texture: Optional[Tuple[bytes, str]] = None,
 ) -> GLTF2:
     """Tessellate a whole shape into a list of triangle vertices and a list of triangle indices."""
-    print("tessellate, obj_color: ", obj_color)
     if texture is None:
         mgr = GLTFMgr()
     else:

--- a/yacv_server/tessellate.py
+++ b/yacv_server/tessellate.py
@@ -21,13 +21,14 @@ def tessellate(
         edges: bool = True,
         vertices: bool = True,
         obj_color: Optional[ColorTuple] = None,
-        base_texture: Optional[Tuple[bytes, str]] = None,
+        texture: Optional[Tuple[bytes, str]] = None,
 ) -> GLTF2:
     """Tessellate a whole shape into a list of triangle vertices and a list of triangle indices."""
-    if base_texture is None:
+    print("tessellate, obj_color: ", obj_color)
+    if texture is None:
         mgr = GLTFMgr()
     else:
-        mgr = GLTFMgr(base_texture)
+        mgr = GLTFMgr(texture)
 
     if isinstance(cad_like, TopLoc_Location):
         mgr.add_location(Location(cad_like))

--- a/yacv_server/tessellate.py
+++ b/yacv_server/tessellate.py
@@ -21,9 +21,13 @@ def tessellate(
         edges: bool = True,
         vertices: bool = True,
         obj_color: Optional[ColorTuple] = None,
+        base_texture: Optional[Tuple[bytes, str]] = None,
 ) -> GLTF2:
     """Tessellate a whole shape into a list of triangle vertices and a list of triangle indices."""
-    mgr = GLTFMgr()
+    if base_texture is None:
+        mgr = GLTFMgr()
+    else:
+        mgr = GLTFMgr(base_texture)
 
     if isinstance(cad_like, TopLoc_Location):
         mgr.add_location(Location(cad_like))

--- a/yacv_server/yacv.py
+++ b/yacv_server/yacv.py
@@ -312,7 +312,7 @@ class YACV:
                     f.write(self.export(name)[0])
 
 
-def _resolve_base_texture() -> Optional[(bytes, str)]:
+def _resolve_base_texture() -> Optional[Tuple[bytes, str]]:
     env_str = os.environ.get("YACV_BASE_TEXTURE")
     if env_str is None:
         return None

--- a/yacv_server/yacv.py
+++ b/yacv_server/yacv.py
@@ -92,6 +92,10 @@ class YACV:
     frontend_lock: RWLock
     """Lock to ensure that the frontend has finished working before we shut down"""
 
+    base_texture: Optional[Tuple[bytes, str]]
+    """Base texture to use for model rendering, in (data, mimetype) format
+    If set to None, will use default checkerboard texture"""
+
     def __init__(self):
         self.server_thread = None
         self.server = None
@@ -283,7 +287,8 @@ class YACV:
                                       faces=event.kwargs.get('faces', True),
                                       edges=event.kwargs.get('edges', True),
                                       vertices=event.kwargs.get('vertices', True),
-                                      obj_color=event.color)
+                                      obj_color=event.color,
+                                      base_texture=self.base_texture)
                     glb_list_of_bytes = gltf.save_to_bytes()
                     glb_bytes = b''.join(glb_list_of_bytes)
                     publish_to.publish(glb_bytes)

--- a/yacv_server/yacv.py
+++ b/yacv_server/yacv.py
@@ -16,6 +16,8 @@ from OCP.TopoDS import TopoDS_Shape
 # noinspection PyProtectedMember
 from build123d import Shape, Axis, Location, Vector, Color
 from dataclasses_json import dataclass_json
+from PIL import Image
+from io import BytesIO
 
 from yacv_server.cad import _hashcode, ColorTuple, get_color
 from yacv_server.cad import get_shape, grab_all_cad, CADCoreLike, CADLike

--- a/yacv_server/yacv.py
+++ b/yacv_server/yacv.py
@@ -14,7 +14,7 @@ from typing import Optional, Dict, Union, Callable, List, Tuple
 from OCP.TopLoc import TopLoc_Location
 from OCP.TopoDS import TopoDS_Shape
 # noinspection PyProtectedMember
-from build123d import Shape, Axis, Location, Vector
+from build123d import Shape, Axis, Location, Vector, Color
 from dataclasses_json import dataclass_json
 
 from yacv_server.cad import _hashcode, ColorTuple, get_color

--- a/yacv_server/yacv.py
+++ b/yacv_server/yacv.py
@@ -106,6 +106,7 @@ class YACV:
         self.at_least_one_client = threading.Event()
         self.shutting_down = threading.Event()
         self.frontend_lock = RWLock()
+        self.base_texture = _resolve_base_texture()
         logger.info('Using yacv-server v%s', get_version())
 
     def start(self):


### PR DESCRIPTION
Personally I do not like the default checkerboard textures for model displays too much and would like to customize it.

Currently it seems that `GLTFMgr` class does export init arguments to alter the base texture, but the arguments connect to nowhere in `tessellate` function and `YACV` class.

This PR connects them together and implements a relatively simple scheme in environment variables to allow the user to specify a base texture using either filepath, base64-encoded string or PIL preset color strings as monocolor texture. The checkerboard texture is still used by default.