### PR TITLE
Don't add location-like objects to Compound()

### DIFF
--- a/yacv_server/cad.py
+++ b/yacv_server/cad.py
@@ -77,8 +77,8 @@ def get_shape(obj: CADLike, error: bool = True) -> Optional[CADCoreLike]:
             if len(shapes_raw_filtered) > 0:  # Continue if we found at least one shape
                 # Sorting is required to improve hashcode consistency
                 shapes_raw_filtered_sorted = sorted(shapes_raw_filtered, key=lambda x: _hashcode(x))
-                # Build a single compound shape
-                shapes_bd = [Compound(shape) for shape in shapes_raw_filtered_sorted if shape is not None]
+                # Build a single compound shape (skip locations/axes here, they can't be in a Compound)
+                shapes_bd = [Compound(shape) for shape in shapes_raw_filtered_sorted if shape is not None and not isinstance(shape, TopLoc_Location)]
                 return get_shape(Compound(shapes_bd), error)
         except TypeError:
             pass


### PR DESCRIPTION
The stack scan likes to look at iterables like lists for objects, but unlike the way it treats local variables, it tries to put them in a Compound() object.  That doesn't work for elements like build123d Location/Pos/Rot which aren't shapes.  Just skip them in those contexts.